### PR TITLE
Implement bulk export capability

### DIFF
--- a/Help/CommandLine.htm
+++ b/Help/CommandLine.htm
@@ -110,6 +110,28 @@ Arguments:
 <CODE>Example: -export -f "Achievement.dbc" -s "E:\WoW\Data\Patch-3.mpq" -b 11802 -o "Achievement.csv"</CODE>
 </P>
 
+<STRONG>Batch Export</STRONG>
+<P>
+Exports multiple files matching a filter to CSV, JSON or a SQL file.
+<BR>
+Arguments:
+<UL>
+<LI>
+-f : File filter, * is used as a wildcard
+<LI>
+-s : Source, this is the optional location of the MPQ file or the CASC directory
+<LI>
+-b : Build number to load the correct definition from
+<LI>
+-o Output directory, this is the folder to export the files to
+<LI>
+-t Output type, CSV, JSON or SQL
+</LI>
+</UL>
+<BR>
+<CODE>Example: -batchexport -f "*.dbc" -s "E:\WoW\Data" -b 12340 -o "C:\Export" -t csv</CODE>
+</P>
+
 <STRONG>SQL Dump</STRONG>
 <P>
 Dumps a specific file's data into a MySQL  database.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ You will need [Microsoft .NET Framework 4.6.1](https://www.microsoft.com/en-us/d
 * A relatively powerful column filter system (similar to boolean search)
 * Displaying and editing columns in hex (numeric columns only)
 * Exporting to a SQL database, SQL file, CSV file and MPQ archives
+* Bulk export of all open files to CSV, SQL or JSON (GUI and `-batchexport` command)
 * Importing from a SQL database and a CSV file
 * An Excel style Find and Replace
 * Shortcuts for common tasks using common shortcut key combinations

--- a/WDBXEditor/Common/Constants.cs
+++ b/WDBXEditor/Common/Constants.cs
@@ -88,19 +88,26 @@ namespace WDBXEditor.Common
 			BfA
 		}
 
-		public enum ExpansionFinalBuild
-		{
-			Alpha = 3494,
-			Beta = 3988,
-			Classic = 6005,
-			TBC = 8606,
-			WotLK = 12340,
-			Cata = 15595,
-			MoP = 18414,
-			WoD = 21742,
-			Legion = 25901,
-			BfA = 26926,
-		}
+                public enum ExpansionFinalBuild
+                {
+                        Alpha = 3494,
+                        Beta = 3988,
+                        Classic = 6005,
+                        TBC = 8606,
+                        WotLK = 12340,
+                        Cata = 15595,
+                        MoP = 18414,
+                        WoD = 21742,
+                        Legion = 25901,
+                        BfA = 26926,
+                }
+
+                public enum OutputType
+                {
+                        CSV,
+                        SQL,
+                        JSON
+                }
 
 		static Constants()
 		{

--- a/WDBXEditor/ConsoleHandler/ConsoleManager.cs
+++ b/WDBXEditor/ConsoleHandler/ConsoleManager.cs
@@ -49,6 +49,7 @@ namespace WDBXEditor.ConsoleHandler
             //Argument commands
             //DefineCommand("-console", ConsoleManager.LoadConsoleMode);
             DefineCommand("-export", ConsoleCommands.ExportArgCommand);
+            DefineCommand("-batchexport", ConsoleCommands.BatchExportCommand);
             DefineCommand("-sqldump", ConsoleCommands.SqlDumpArgCommand);
             DefineCommand("-extract", ConsoleCommands.ExtractCommand);
         }

--- a/WDBXEditor/Main.Designer.cs
+++ b/WDBXEditor/Main.Designer.cs
@@ -78,10 +78,11 @@ namespace WDBXEditor
 			this.exportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.toSQLToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.toSQLFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toCSVToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toMPQToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toJSONToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.importToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+                        this.toCSVToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+                        this.toMPQToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+                        this.toJSONToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+                        this.batchExportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+                        this.importToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.fromSQLToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.fromCSVToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.optionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -529,7 +530,8 @@ namespace WDBXEditor
             this.toSQLFileToolStripMenuItem,
             this.toCSVToolStripMenuItem,
             this.toMPQToolStripMenuItem,
-            this.toJSONToolStripMenuItem});
+            this.toJSONToolStripMenuItem,
+            this.batchExportToolStripMenuItem});
 			this.exportToolStripMenuItem.Name = "exportToolStripMenuItem";
 			this.exportToolStripMenuItem.Size = new System.Drawing.Size(52, 20);
 			this.exportToolStripMenuItem.Text = "Export";
@@ -572,9 +574,17 @@ namespace WDBXEditor
 			this.toJSONToolStripMenuItem.Name = "toJSONToolStripMenuItem";
 			this.toJSONToolStripMenuItem.Size = new System.Drawing.Size(132, 22);
 			this.toJSONToolStripMenuItem.Text = "To JSON";
-			this.toJSONToolStripMenuItem.Click += new System.EventHandler(this.toJSONToolStripMenuItem_Click);
-			// 
-			// importToolStripMenuItem
+                        this.toJSONToolStripMenuItem.Click += new System.EventHandler(this.toJSONToolStripMenuItem_Click);
+                        //
+                        // batchExportToolStripMenuItem
+                        //
+                        this.batchExportToolStripMenuItem.Image = global::WDBXEditor.Properties.Resources.save_file;
+                        this.batchExportToolStripMenuItem.Name = "batchExportToolStripMenuItem";
+                        this.batchExportToolStripMenuItem.Size = new System.Drawing.Size(132, 22);
+                        this.batchExportToolStripMenuItem.Text = "Batch Export";
+                        this.batchExportToolStripMenuItem.Click += new System.EventHandler(this.batchExportToolStripMenuItem_Click);
+                        //
+                        // importToolStripMenuItem
 			// 
 			this.importToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.fromSQLToolStripMenuItem,
@@ -964,6 +974,7 @@ namespace WDBXEditor
         private System.Windows.Forms.ToolStripMenuItem deleteLineToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem saveAsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem toJSONToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem batchExportToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem playerLocationRecorderToolStripMenuItem;
         private System.Windows.Forms.ComboBox cbColumnMode;
         private System.Windows.Forms.Label label8;

--- a/WDBXEditor/Main.cs
+++ b/WDBXEditor/Main.cs
@@ -772,9 +772,9 @@ namespace WDBXEditor
 		/// </summary>
 		/// <param name="sender"></param>
 		/// <param name="e"></param>
-		private void toJSONToolStripMenuItem_Click(object sender, EventArgs e)
-		{
-			if (!IsLoaded) return;
+                private void toJSONToolStripMenuItem_Click(object sender, EventArgs e)
+                {
+                        if (!IsLoaded) return;
 
 			using (var sfd = new SaveFileDialog())
 			{
@@ -802,10 +802,39 @@ namespace WDBXEditor
 						else
 							MessageBox.Show($"File successfully exported to {sfd.FileName}");
 
-					}, TaskScheduler.FromCurrentSynchronizationContext());
-				}
-			}
-		}
+                                        }, TaskScheduler.FromCurrentSynchronizationContext());
+                                }
+                        }
+                }
+
+                private void batchExportToolStripMenuItem_Click(object sender, EventArgs e)
+                {
+                        using (var fbd = new FolderBrowserDialog())
+                        {
+                                if (fbd.ShowDialog(this) == DialogResult.OK)
+                                {
+                                        string res = "CSV";
+                                        if (ShowInputDialog("Format (CSV, SQL, JSON):", "Export Format", res, ref res) != DialogResult.OK)
+                                                return;
+
+                                        if (!Enum.TryParse(res, true, out OutputType type))
+                                        {
+                                                MessageBox.Show("Invalid format selected.");
+                                                return;
+                                        }
+
+                                        ProgressBarHandle(true, "Exporting files...");
+                                        Task.Run(() => Database.ExportFiles(fbd.SelectedPath, type))
+                                                .ContinueWith(x =>
+                                                {
+                                                        if (x.Result.Count > 0)
+                                                                new ErrorReport(x.Result).ShowDialog(this);
+
+                                                        ProgressBarHandle(false);
+                                                }, TaskScheduler.FromCurrentSynchronizationContext());
+                                }
+                        }
+                }
 
 		#endregion
 


### PR DESCRIPTION
## Summary
- add `OutputType` enum in constants
- enable `Database.ExportFiles` for CSV/JSON/SQL bulk export
- expose batch export via GUI
- add `-batchexport` console command
- document the new feature

## Testing
- `dotnet --version` *(fails: command not found)*
- `msbuild /version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f532a0740832e84675edcc5b076a2