### PR TITLE
Update projects to .NET 4.8

### DIFF
--- a/AdvancedDataGridView/AdvancedDataGridView.csproj
+++ b/AdvancedDataGridView/AdvancedDataGridView.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ADGV</RootNamespace>
     <AssemblyName>AdvancedDataGridView</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>

--- a/WDBXEditor/WDBXEditor.csproj
+++ b/WDBXEditor/WDBXEditor.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>WDBXEditor</RootNamespace>
     <AssemblyName>WDBX Editor</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <IsWebBootstrapper>false</IsWebBootstrapper>
@@ -104,7 +104,7 @@
   <PropertyGroup />
   <ItemGroup>
     <Reference Include="MySql.Data, Version=6.9.9.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d, processorArchitecture=MSIL">
-      <HintPath>..\packages\MySql.Data.6.9.9\lib\net45\MySql.Data.dll</HintPath>
+      <HintPath>..\packages\MySql.Data.6.9.9\lib\net48\MySql.Data.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -114,7 +114,7 @@
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Threading.Tasks.Dataflow, Version=4.6.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Threading.Tasks.Dataflow.4.7.0\lib\portable-net45+win8+wpa81\System.Threading.Tasks.Dataflow.dll</HintPath>
+      <HintPath>..\packages\System.Threading.Tasks.Dataflow.4.7.0\lib\net48\System.Threading.Tasks.Dataflow.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Transactions" />

--- a/WDBXEditor/packages.config
+++ b/WDBXEditor/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MySql.Data" version="6.9.9" targetFramework="net461" />
-  <package id="System.Threading.Tasks.Dataflow" version="4.7.0" targetFramework="net461" />
+  <package id="MySql.Data" version="6.9.9" targetFramework="net48" />
+  <package id="System.Threading.Tasks.Dataflow" version="4.7.0" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
## Summary
- target .NET Framework 4.8 for both csproj files
- update hint paths to use `net48`
- adjust package config framework version

## Testing
- `nuget restore WDBXEditor.sln` *(fails: command not found)*
- `msbuild WDBXEditor.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f575b7590832e9bf944dbc874c699