### PR TITLE
Fix unreachable break in SaveFiles

### DIFF
--- a/WDBXEditor/Storage/Database.cs
+++ b/WDBXEditor/Storage/Database.cs
@@ -201,7 +201,6 @@ namespace WDBXEditor.Storage
                                                         case OutputType.JSON:
                                                                 WriteJsonChunks(file, folder, MaxJsonBytes);
                                                                 goto SkipWrite;
-                                                                break;
                                                 }
 
                                                 File.WriteAllText(path, data);


### PR DESCRIPTION
## Summary
- remove `break;` after `goto SkipWrite` to avoid unreachable code warning

## Testing
- `dotnet build WDBXEditor.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fd08499dc832ea8db1e4dde8b8ee2