### PR TITLE
Enable msbuild package restore

### DIFF
--- a/WDBXEditor/WDBXEditor.csproj
+++ b/WDBXEditor/WDBXEditor.csproj
@@ -29,6 +29,7 @@
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
## Summary
- allow msbuild `/t:Restore` by setting `RestorePackages` flag in `WDBXEditor.csproj`

## Testing
- `nuget restore WDBXEditor.sln` *(fails: command not found)*
- `msbuild /t:Restore WDBXEditor.sln` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_684fd44f4640832e92551754886f4ae6