### PR TITLE
Implement column rename feature in DB2 viewer

### DIFF
--- a/AdvancedDataGridView/AdvancedDataGridView.cs
+++ b/AdvancedDataGridView/AdvancedDataGridView.cs
@@ -17,6 +17,7 @@ namespace ADGV
     {
         public event EventHandler SortStringChanged;
         public event EventHandler FilterStringChanged;
+        public event ColumnHeaderCellEventHandler RenameColumn;
 
         public ContextMenu HeaderContext { get; set; }
         public bool FilterAndSortEnabled { get; set; }
@@ -108,6 +109,7 @@ namespace ADGV
             cell.FilterPopup += new ColumnHeaderCellEventHandler(cell_FilterPopup);
             cell.HideChanged += new ColumnHeaderCellEventHandler(cell_HideChanged);
             cell.HexChanged += new ColumnHeaderCellEventHandler(cell_HexChanged);
+            cell.RenameRequested += new ColumnHeaderCellEventHandler(cell_RenameRequested);
         }
 
         protected override void OnColumnRemoved(DataGridViewColumnEventArgs e)
@@ -124,6 +126,7 @@ namespace ADGV
                 cell.FilterPopup -= cell_FilterPopup;
                 cell.HideChanged -= cell_HideChanged;
                 cell.HexChanged -= cell_HexChanged;
+                cell.RenameRequested -= cell_RenameRequested;
             }
             base.OnColumnRemoved(e);
         }
@@ -340,6 +343,11 @@ namespace ADGV
                 e.Column.DefaultCellStyle.Tag = $"X";
 
             this.Refresh();
+        }
+
+        private void cell_RenameRequested(object sender, ColumnHeaderCellEventArgs e)
+        {
+            RenameColumn?.Invoke(this, e);
         }
 
         #endregion

--- a/AdvancedDataGridView/ColumnHeader.cs
+++ b/AdvancedDataGridView/ColumnHeader.cs
@@ -13,6 +13,7 @@ namespace ADGV
         public event ColumnHeaderCellEventHandler FilterChanged;
         public event ColumnHeaderCellEventHandler HideChanged;
         public event ColumnHeaderCellEventHandler HexChanged;
+        public event ColumnHeaderCellEventHandler RenameRequested;
 
         public ColumnMenu MenuStrip { get; private set; }
         public bool FilterAndSortEnabled
@@ -141,6 +142,7 @@ namespace ADGV
                 MenuStrip.SortChanged += new EventHandler(menuStrip_SortChanged);
                 MenuStrip.HexChanged += new EventHandler(menuStrip_HexChanged);
                 MenuStrip.HideChanged += new EventHandler(menuStrip_HideChanged);
+                MenuStrip.RenameRequested += new EventHandler(menuStrip_RenameRequested);
             }
             else
             {
@@ -149,6 +151,7 @@ namespace ADGV
                 MenuStrip.SortChanged += new EventHandler(menuStrip_SortChanged);
                 MenuStrip.HexChanged += new EventHandler(menuStrip_HexChanged);
                 MenuStrip.HideChanged += new EventHandler(menuStrip_HideChanged);
+                MenuStrip.RenameRequested += new EventHandler(menuStrip_RenameRequested);
                 MenuStrip.IsSortEnabled = true;
                 MenuStrip.IsFilterEnabled = true;
             }
@@ -162,6 +165,7 @@ namespace ADGV
                 MenuStrip.SortChanged -= menuStrip_SortChanged;
                 MenuStrip.HexChanged -= menuStrip_HexChanged;
                 MenuStrip.HideChanged -= menuStrip_HideChanged;
+                MenuStrip.RenameRequested -= menuStrip_RenameRequested;
             }
         }
 
@@ -257,6 +261,11 @@ namespace ADGV
         {
             if (HexChanged != null)
                 HexChanged(this, new ColumnHeaderCellEventArgs(MenuStrip, OwningColumn));
+        }
+
+        private void menuStrip_RenameRequested(object sender, EventArgs e)
+        {
+            RenameRequested?.Invoke(this, new ColumnHeaderCellEventArgs(MenuStrip, OwningColumn));
         }
         #endregion
 

--- a/AdvancedDataGridView/ColumnMenu.cs
+++ b/AdvancedDataGridView/ColumnMenu.cs
@@ -31,6 +31,7 @@ namespace ADGV
         public event EventHandler FilterChanged;
         public event EventHandler HexChanged;
         public event EventHandler HideChanged;
+        public event EventHandler RenameRequested;
 
         public SortType ActiveSortType
         {
@@ -80,6 +81,7 @@ namespace ADGV
             _textStrings.Add("NODESELECTALL", "(Select All)");
             _textStrings.Add("NODESELECTEMPTY", "(Blanks)");
             _textStrings.Add("HIDECOLUMN", "Hide");
+            _textStrings.Add("RENAMECOLUMN", "Rename");
             
             InitializeComponent();
             
@@ -365,6 +367,11 @@ namespace ADGV
         private void hideMenuItem_Click(object sender, EventArgs e)
         {
             HideChanged(this, new EventArgs());
+        }
+
+        private void renameMenuItem_Click(object sender, EventArgs e)
+        {
+            RenameRequested?.Invoke(this, new EventArgs());
         }
 
         private void sortASCMenuItem_Click(object sender, EventArgs e)

--- a/AdvancedDataGridView/ColumnMenu.designer.cs
+++ b/AdvancedDataGridView/ColumnMenu.designer.cs
@@ -104,6 +104,13 @@ namespace ADGV
             this.hideMenuItem.AutoSize = true;
             this.hideMenuItem.Size = new System.Drawing.Size(Width - 1, 22);
             this.hideMenuItem.Text = "Hide";
+            //
+            // renameMenuItem
+            //
+            this.renameMenuItem.Name = "renameMenuItem";
+            this.renameMenuItem.AutoSize = true;
+            this.renameMenuItem.Size = new System.Drawing.Size(Width - 1, 22);
+            this.renameMenuItem.Text = "Rename";
 
             this.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
                 hexDisplayMenuItem,
@@ -113,7 +120,9 @@ namespace ADGV
                 cancelSortMenuItem,
                 toolStripSeparator1MenuItem,
                 customFilterLastFiltersListMenuItem,
-                cancelFilterMenuItem,                
+                cancelFilterMenuItem,
+                hideMenuItem,
+                renameMenuItem,
             });
             
             this.Closed += new System.Windows.Forms.ToolStripDropDownClosedEventHandler(MenuStrip_Closed);
@@ -128,6 +137,7 @@ namespace ADGV
             this.cancelSortMenuItem.MouseEnter += new System.EventHandler(cancelSortMenuItem_MouseEnter);
             this.customFilterLastFiltersListMenuItem.Click += new System.EventHandler(customFilterMenuItem_Click);
             this.hideMenuItem.Click += new System.EventHandler(hideMenuItem_Click);
+            this.renameMenuItem.Click += new System.EventHandler(renameMenuItem_Click);
             this.hexDisplayMenuItem.Click += new System.EventHandler(hexDisplayMenuItem_Click);
 
 
@@ -145,5 +155,6 @@ namespace ADGV
         private System.Windows.Forms.ToolStripMenuItem customFilterLastFiltersListMenuItem;
         private System.Windows.Forms.ToolStripMenuItem hexDisplayMenuItem;
         private System.Windows.Forms.ToolStripMenuItem hideMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem renameMenuItem;
     }
 }

--- a/WDBXEditor/Main.Designer.cs
+++ b/WDBXEditor/Main.Designer.cs
@@ -796,15 +796,16 @@ namespace WDBXEditor
 			this.advancedDataGridView.TabIndex = 0;
 			this.advancedDataGridView.UndoRedoChanged += new System.EventHandler(this.advancedDataGridView_UndoRedoChanged);
 			this.advancedDataGridView.SortStringChanged += new System.EventHandler(this.advancedDataGridView_SortStringChanged);
-			this.advancedDataGridView.FilterStringChanged += new System.EventHandler(this.advancedDataGridView_FilterStringChanged);
-			this.advancedDataGridView.CellValueChanged += new System.Windows.Forms.DataGridViewCellEventHandler(this.advancedDataGridView_CellValueChanged);
-			this.advancedDataGridView.CurrentCellChanged += new System.EventHandler(this.advancedDataGridView_CurrentCellChanged);
-			this.advancedDataGridView.DataBindingComplete += new System.Windows.Forms.DataGridViewBindingCompleteEventHandler(this.advancedDataGridView_DataBindingComplete);
-			this.advancedDataGridView.RowsAdded += new System.Windows.Forms.DataGridViewRowsAddedEventHandler(this.advancedDataGridView_RowsAdded);
-			this.advancedDataGridView.RowsRemoved += new System.Windows.Forms.DataGridViewRowsRemovedEventHandler(this.advancedDataGridView_RowsRemoved);
-			this.advancedDataGridView.DragDrop += new System.Windows.Forms.DragEventHandler(this.advancedDataGridView_DragDrop);
-			this.advancedDataGridView.DragEnter += new System.Windows.Forms.DragEventHandler(this.advancedDataGridView_DragEnter);
-			this.advancedDataGridView.MouseDown += new System.Windows.Forms.MouseEventHandler(this.advancedDataGridView_MouseDown);
+                        this.advancedDataGridView.FilterStringChanged += new System.EventHandler(this.advancedDataGridView_FilterStringChanged);
+                        this.advancedDataGridView.CellValueChanged += new System.Windows.Forms.DataGridViewCellEventHandler(this.advancedDataGridView_CellValueChanged);
+                        this.advancedDataGridView.CurrentCellChanged += new System.EventHandler(this.advancedDataGridView_CurrentCellChanged);
+                        this.advancedDataGridView.DataBindingComplete += new System.Windows.Forms.DataGridViewBindingCompleteEventHandler(this.advancedDataGridView_DataBindingComplete);
+                        this.advancedDataGridView.RowsAdded += new System.Windows.Forms.DataGridViewRowsAddedEventHandler(this.advancedDataGridView_RowsAdded);
+                        this.advancedDataGridView.RowsRemoved += new System.Windows.Forms.DataGridViewRowsRemovedEventHandler(this.advancedDataGridView_RowsRemoved);
+                        this.advancedDataGridView.DragDrop += new System.Windows.Forms.DragEventHandler(this.advancedDataGridView_DragDrop);
+                        this.advancedDataGridView.DragEnter += new System.Windows.Forms.DragEventHandler(this.advancedDataGridView_DragEnter);
+                        this.advancedDataGridView.RenameColumn += new ADGV.ColumnHeaderCellEventHandler(this.advancedDataGridView_RenameColumn);
+                        this.advancedDataGridView.MouseDown += new System.Windows.Forms.MouseEventHandler(this.advancedDataGridView_MouseDown);
 			// 
 			// cbColumnMode
 			// 

--- a/WDBXEditor/Main.cs
+++ b/WDBXEditor/Main.cs
@@ -250,11 +250,36 @@ namespace WDBXEditor
 			}
 		}
 
-		private void advancedDataGridView_UndoRedoChanged(object sender, EventArgs e)
-		{
-			undoToolStripMenuItem.Enabled = advancedDataGridView.CanUndo;
-			redoToolStripMenuItem.Enabled = advancedDataGridView.CanRedo;
-		}
+                private void advancedDataGridView_UndoRedoChanged(object sender, EventArgs e)
+                {
+                        undoToolStripMenuItem.Enabled = advancedDataGridView.CanUndo;
+                        redoToolStripMenuItem.Enabled = advancedDataGridView.CanRedo;
+                }
+
+                private void advancedDataGridView_RenameColumn(object sender, ADGV.ColumnHeaderCellEventArgs e)
+                {
+                        if (!IsLoaded || e.Column == null)
+                                return;
+
+                        string newName = e.Column.HeaderText;
+                        if (ShowInputDialog("New column name:", "Rename Column", newName, ref newName) == DialogResult.OK)
+                        {
+                                if (string.IsNullOrWhiteSpace(newName) || LoadedEntry.Data.Columns.Contains(newName))
+                                {
+                                        MessageBox.Show("Invalid or duplicate column name.");
+                                        return;
+                                }
+
+                                string oldName = e.Column.Name;
+                                LoadedEntry.RenameColumn(oldName, newName);
+                                e.Column.Name = newName;
+                                e.Column.DataPropertyName = newName;
+                                e.Column.HeaderText = newName;
+
+                                columnFilter.Reset(LoadedEntry.Data.Columns, true);
+                                Database.Definitions.SaveDefinitions();
+                        }
+                }
 
 		private void advancedDataGridView_DragEnter(object sender, DragEventArgs e)
 		{

--- a/WDBXEditor/Storage/DBEntry.cs
+++ b/WDBXEditor/Storage/DBEntry.cs
@@ -466,14 +466,56 @@ namespace WDBXEditor.Storage
 			return result;
 		}
 
-		public void ResetTemp()
-		{
-			min = -1;
-			max = -1;
-			unqiueRowIndices = null;
-			primaryKeys = null;
-		}
-		#endregion
+                public void ResetTemp()
+                {
+                        min = -1;
+                        max = -1;
+                        unqiueRowIndices = null;
+                        primaryKeys = null;
+                }
+
+                public void RenameColumn(string oldName, string newName)
+                {
+                        if (!Data.Columns.Contains(oldName))
+                                return;
+
+                        Data.Columns[oldName].ColumnName = newName;
+
+                        foreach (var field in TableStructure.Fields)
+                        {
+                                string[] names = field.ColumnNames.Split(',');
+                                for (int i = 0; i < field.ArraySize; i++)
+                                {
+                                        string columnName = field.Name;
+                                        if (field.ArraySize > 1)
+                                        {
+                                                if (names.Length >= (i + 1) && !string.IsNullOrWhiteSpace(names[i]))
+                                                        columnName = names[i];
+                                                else
+                                                        columnName = field.Name + "_" + (i + 1);
+                                        }
+
+                                        if (columnName == oldName)
+                                        {
+                                                if (field.ArraySize > 1)
+                                                {
+                                                        if (names.Length < field.ArraySize)
+                                                                Array.Resize(ref names, field.ArraySize);
+                                                        names[i] = newName;
+                                                        field.ColumnNames = string.Join(",", names);
+                                                }
+                                                else
+                                                {
+                                                        field.Name = newName;
+                                                }
+
+                                                field.InternalName = newName;
+                                                return;
+                                        }
+                                }
+                        }
+                }
+                #endregion
 
 
 		#region Exports


### PR DESCRIPTION
## Summary
- allow renaming columns through AdvancedDataGridView column menu
- propagate rename event through ColumnHeader and AdvancedDataGridView
- update Main form to handle column rename and persist definition changes
- expose helper `RenameColumn` on DBEntry to update DataTable and definitions

## Testing
- `dotnet build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6861b7512584832e83b544f4b08c8fb4