### PR TITLE
Fix delegate accessibility

### DIFF
--- a/AdvancedDataGridView/ColumnHeader.cs
+++ b/AdvancedDataGridView/ColumnHeader.cs
@@ -419,8 +419,8 @@ namespace ADGV
 
     }
 
-    internal delegate void ColumnHeaderCellEventHandler(object sender, ColumnHeaderCellEventArgs e);
-    internal class ColumnHeaderCellEventArgs : EventArgs
+    public delegate void ColumnHeaderCellEventHandler(object sender, ColumnHeaderCellEventArgs e);
+    public class ColumnHeaderCellEventArgs : EventArgs
     {
         public ColumnMenu FilterMenu { get; private set; }
 


### PR DESCRIPTION
## Summary
- make the delegate and EventArgs for column events public so external assemblies can compile

## Testing
- `dotnet build WDBXEditor.sln -c Release -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861b9be5b00832eb04f761eb48e3e58